### PR TITLE
SA-8536: support per-identity clients in the dynamicinformer watch registry

### DIFF
--- a/dynamicinformer/registry.go
+++ b/dynamicinformer/registry.go
@@ -14,11 +14,17 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// WatchKey uniquely identifies a watch by GVR and namespace.
+// WatchKey uniquely identifies a watch by GVR, namespace, and identity.
 // An empty namespace means cluster-scoped.
+//
+// Identity selects which client the informer is started with (see ClientProvider)
+// and is part of the key on purpose: watches under different identities are never
+// shared, since they may be authorized differently. The registry treats the value
+// as opaque; an empty identity means the registry's default client.
 type WatchKey struct {
 	GVR       schema.GroupVersionResource
 	Namespace string
+	Identity  string
 }
 
 // WatchRequest pairs a watch key with its callback. Passed as a slice to EnsureWatchSet.
@@ -55,6 +61,30 @@ type WatchRegistration struct {
 	HasSynced  cache.InformerSynced
 }
 
+// ClientProvider supplies the dynamic client for a given identity. The identity
+// string is opaque to the registry — which credentials or cluster it maps to is
+// entirely up to the implementation. An empty identity must return the default
+// client.
+//
+// Implementations must be safe for concurrent use and should cache clients per
+// identity, since ClientFor is called every time an informer starts.
+type ClientProvider interface {
+	ClientFor(identity string) (dynamic.Interface, error)
+}
+
+// singleClientProvider serves one fixed client for the empty identity only.
+// It backs NewWatchRegistry for callers that predate identities.
+type singleClientProvider struct {
+	client dynamic.Interface
+}
+
+func (p singleClientProvider) ClientFor(identity string) (dynamic.Interface, error) {
+	if identity != "" {
+		return nil, fmt.Errorf("registry was built without a ClientProvider; cannot serve identity %q", identity)
+	}
+	return p.client, nil
+}
+
 // WatchRegistry manages dynamic informers for arbitrary GroupVersionResource types
 // at runtime. Each consumer registers callbacks per watch key. The registry deduplicates
 // informers, manages handler lifecycle, and cleans up stale watches automatically.
@@ -64,18 +94,26 @@ type WatchRegistry struct {
 	mu           sync.Mutex
 	watches      map[WatchKey]*WatchEntry
 	consumerKeys map[string]map[WatchKey]struct{} // consumerID → set of WatchKeys
-	dynamic      dynamic.Interface
+	clients      ClientProvider
 	resyncPeriod time.Duration
 }
 
 // NewWatchRegistry creates a new registry backed by the given dynamic client.
+// All watch keys must use the empty identity. Use NewWatchRegistryWithProvider
+// to serve watches under multiple identities.
 // The resyncPeriod controls how often each informer relists from the API server.
 // A non-zero value is required to recover from dropped events (30s is typical).
 func NewWatchRegistry(dynamicClient dynamic.Interface, resyncPeriod time.Duration) *WatchRegistry {
+	return NewWatchRegistryWithProvider(singleClientProvider{client: dynamicClient}, resyncPeriod)
+}
+
+// NewWatchRegistryWithProvider creates a registry that resolves the client for
+// each watch from the provider, keyed by WatchKey.Identity.
+func NewWatchRegistryWithProvider(provider ClientProvider, resyncPeriod time.Duration) *WatchRegistry {
 	return &WatchRegistry{
 		watches:      make(map[WatchKey]*WatchEntry),
 		consumerKeys: make(map[string]map[WatchKey]struct{}),
-		dynamic:      dynamicClient,
+		clients:      provider,
 		resyncPeriod: resyncPeriod,
 	}
 }
@@ -178,10 +216,23 @@ func (r *WatchRegistry) EnsureWatchSet(
 
 		entry, exists := r.watches[key]
 		if !exists {
+			cli, err := r.clients.ClientFor(key.Identity)
+			if err != nil {
+				// Same recovery contract as an AddEventHandler failure below:
+				// roll back handlers added in this call, keep the previous set.
+				rollbackErrs := []error{fmt.Errorf("failed to get client for %v: %w", key, err)}
+				for _, key := range newlyAdded {
+					if rErr := r.releaseWatchLocked(key, consumerID); rErr != nil {
+						rollbackErrs = append(rollbackErrs, rErr)
+					}
+				}
+				return nil, errors.Join(rollbackErrs...)
+			}
+
 			ctx, cancel := context.WithCancel(parentCtx)
 
 			factory := kubedynamicinformer.NewFilteredDynamicSharedInformerFactory(
-				r.dynamic,
+				cli,
 				r.resyncPeriod,
 				key.Namespace,
 				nil,

--- a/dynamicinformer/registry.go
+++ b/dynamicinformer/registry.go
@@ -64,7 +64,8 @@ type WatchRegistration struct {
 // ClientProvider supplies the dynamic client for a given identity. The identity
 // string is opaque to the registry — which credentials or cluster it maps to is
 // entirely up to the implementation. An empty identity must return the default
-// client.
+// client. Implementations must never return (nil, nil); the registry rejects a
+// nil client defensively.
 //
 // Implementations must be safe for concurrent use and should cache clients per
 // identity, since ClientFor is called every time an informer starts.
@@ -80,7 +81,10 @@ type singleClientProvider struct {
 
 func (p singleClientProvider) ClientFor(identity string) (dynamic.Interface, error) {
 	if identity != "" {
-		return nil, fmt.Errorf("registry was built without a ClientProvider; cannot serve identity %q", identity)
+		return nil, fmt.Errorf("identity %q is not supported: this registry serves only the default identity (use NewWatchRegistryWithProvider for per-identity clients)", identity)
+	}
+	if p.client == nil {
+		return nil, fmt.Errorf("registry was created with a nil dynamic client")
 	}
 	return p.client, nil
 }
@@ -217,16 +221,14 @@ func (r *WatchRegistry) EnsureWatchSet(
 		entry, exists := r.watches[key]
 		if !exists {
 			cli, err := r.clients.ClientFor(key.Identity)
+			if err == nil && cli == nil {
+				// The provider is caller-supplied; guard against (nil, nil) so
+				// the failure surfaces here instead of a panic inside the informer.
+				err = fmt.Errorf("ClientFor returned a nil client")
+			}
 			if err != nil {
-				// Same recovery contract as an AddEventHandler failure below:
-				// roll back handlers added in this call, keep the previous set.
-				rollbackErrs := []error{fmt.Errorf("failed to get client for %v: %w", key, err)}
-				for _, key := range newlyAdded {
-					if rErr := r.releaseWatchLocked(key, consumerID); rErr != nil {
-						rollbackErrs = append(rollbackErrs, rErr)
-					}
-				}
-				return nil, errors.Join(rollbackErrs...)
+				return nil, r.rollbackNewlyAddedLocked(consumerID, newlyAdded,
+					fmt.Errorf("failed to get client for %v: %w", key, err))
 			}
 
 			ctx, cancel := context.WithCancel(parentCtx)
@@ -261,15 +263,8 @@ func (r *WatchRegistry) EnsureWatchSet(
 
 		reg, err := entry.informer.AddEventHandler(callbackToHandler(w.Callback))
 		if err != nil {
-			// Clean up only handlers added in this call; deduped (pre-existing)
-			// handlers are untouched so the consumer keeps its previous state.
-			rollbackErrs := []error{fmt.Errorf("failed to add event handler for %v: %w", key, err)}
-			for _, key := range newlyAdded {
-				if rErr := r.releaseWatchLocked(key, consumerID); rErr != nil {
-					rollbackErrs = append(rollbackErrs, rErr)
-				}
-			}
-			return nil, errors.Join(rollbackErrs...)
+			return nil, r.rollbackNewlyAddedLocked(consumerID, newlyAdded,
+				fmt.Errorf("failed to add event handler for %v: %w", key, err))
 		}
 
 		entry.handlers[consumerID] = &handlerRegistration{
@@ -295,6 +290,20 @@ func (r *WatchRegistry) EnsureWatchSet(
 	r.consumerKeys[consumerID] = newCurrent
 
 	return regs, errors.Join(errs...)
+}
+
+// rollbackNewlyAddedLocked releases the watches added earlier in the same
+// EnsureWatchSet call and joins any release errors onto cause. Deduped
+// (pre-existing) handlers are untouched, so the consumer keeps its previous
+// watch set on failure. Caller must hold r.mu.
+func (r *WatchRegistry) rollbackNewlyAddedLocked(consumerID string, newlyAdded []WatchKey, cause error) error {
+	errs := []error{cause}
+	for _, key := range newlyAdded {
+		if rErr := r.releaseWatchLocked(key, consumerID); rErr != nil {
+			errs = append(errs, rErr)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // ReleaseAll releases all registrations for a given consumer across all watch keys.

--- a/dynamicinformer/registry_test.go
+++ b/dynamicinformer/registry_test.go
@@ -1068,6 +1068,44 @@ func TestEnsureWatchSet_ProviderErrorRollsBack(t *testing.T) {
 	}
 }
 
+// nilClientProvider returns (nil, nil) — an invalid implementation the
+// registry must reject instead of panicking inside the informer.
+type nilClientProvider struct{}
+
+func (nilClientProvider) ClientFor(string) (dynamic.Interface, error) { return nil, nil }
+
+func TestEnsureWatchSet_NilClientFromProviderIsRejected(t *testing.T) {
+	registry := NewWatchRegistryWithProvider(nilClientProvider{}, 30*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := registry.EnsureWatchSet(ctx, "consumer-1", []WatchRequest{
+		{Key: WatchKey{GVR: deploymentsGVR, Namespace: "default"}, Callback: noopCallback()},
+	})
+	if err == nil {
+		t.Fatal("expected error for provider returning nil client")
+	}
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if len(registry.watches) != 0 {
+		t.Errorf("expected no watches after nil-client rejection, got %d", len(registry.watches))
+	}
+}
+
+func TestNewWatchRegistry_NilClientIsRejected(t *testing.T) {
+	registry := NewWatchRegistry(nil, 30*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := registry.EnsureWatchSet(ctx, "consumer-1", []WatchRequest{
+		{Key: WatchKey{GVR: deploymentsGVR, Namespace: "default"}, Callback: noopCallback()},
+	})
+	if err == nil {
+		t.Fatal("expected error for registry created with nil client")
+	}
+}
+
 func TestNewWatchRegistry_RejectsNonEmptyIdentity(t *testing.T) {
 	registry, ctx, cancel := newFakeRegistry(t) // legacy single-client constructor
 	defer cancel()

--- a/dynamicinformer/registry_test.go
+++ b/dynamicinformer/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -21,20 +22,56 @@ var (
 	deploymentsGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	servicesGVR    = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
 	configmapsGVR  = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	secretsGVR     = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 )
 
-func newFakeRegistry(t *testing.T) (*WatchRegistry, context.Context, context.CancelFunc) {
-	t.Helper()
+func newFakeDynamicClient() *dynamicfake.FakeDynamicClient {
 	scheme := runtime.NewScheme()
 	gvrToListKind := map[schema.GroupVersionResource]string{
 		deploymentsGVR: "DeploymentList",
 		servicesGVR:    "ServiceList",
 		configmapsGVR:  "ConfigMapList",
+		secretsGVR:     "SecretList",
 	}
-	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
-	registry := NewWatchRegistry(client, 30*time.Second)
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+}
+
+func newFakeRegistry(t *testing.T) (*WatchRegistry, context.Context, context.CancelFunc) {
+	t.Helper()
+	registry := NewWatchRegistry(newFakeDynamicClient(), 30*time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
 	return registry, ctx, cancel
+}
+
+// fakeClientProvider serves a distinct fake dynamic client per identity and
+// records which identities were requested. Identities in errFor fail.
+type fakeClientProvider struct {
+	mu      sync.Mutex
+	clients map[string]dynamic.Interface
+	calls   []string
+	errFor  map[string]error
+}
+
+func newFakeClientProvider() *fakeClientProvider {
+	return &fakeClientProvider{
+		clients: make(map[string]dynamic.Interface),
+		errFor:  make(map[string]error),
+	}
+}
+
+func (p *fakeClientProvider) ClientFor(identity string) (dynamic.Interface, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, identity)
+	if err, ok := p.errFor[identity]; ok {
+		return nil, err
+	}
+	cli, ok := p.clients[identity]
+	if !ok {
+		cli = newFakeDynamicClient()
+		p.clients[identity] = cli
+	}
+	return cli, nil
 }
 
 func noopCallback() EventCallback {
@@ -864,6 +901,205 @@ func TestEnsureWatchSet_EmptySliceUnknownConsumer(t *testing.T) {
 	}
 	if len(registry.consumerKeys) != 0 {
 		t.Errorf("expected 0 consumer keys, got %d", len(registry.consumerKeys))
+	}
+}
+
+// --- Identity tests ---
+
+func TestEnsureWatchSet_DifferentIdentitiesDifferentInformers(t *testing.T) {
+	provider := newFakeClientProvider()
+	registry := NewWatchRegistryWithProvider(provider, 30*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watches := []WatchRequest{
+		{
+			Key:      WatchKey{GVR: secretsGVR, Namespace: "shared", Identity: "team-a/reader"},
+			Callback: noopCallback(),
+		},
+		{
+			Key:      WatchKey{GVR: secretsGVR, Namespace: "shared", Identity: "team-b/reader"},
+			Callback: noopCallback(),
+		},
+	}
+
+	regs, err := registry.EnsureWatchSet(ctx, "consumer-1", watches)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(regs) != 2 {
+		t.Fatalf("expected 2 registrations, got %d", len(regs))
+	}
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	// Same GVR+namespace but different identities = separate informers
+	if len(registry.watches) != 2 {
+		t.Errorf("expected 2 watch entries for different identities, got %d", len(registry.watches))
+	}
+
+	// Each informer must have been built from its own identity's client
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.calls) != 2 {
+		t.Fatalf("expected 2 ClientFor calls, got %d (%v)", len(provider.calls), provider.calls)
+	}
+	seen := map[string]bool{}
+	for _, id := range provider.calls {
+		seen[id] = true
+	}
+	if !seen["team-a/reader"] || !seen["team-b/reader"] {
+		t.Errorf("expected ClientFor calls for both identities, got %v", provider.calls)
+	}
+}
+
+func TestEnsureWatchSet_SameIdentitySharesInformer(t *testing.T) {
+	provider := newFakeClientProvider()
+	registry := NewWatchRegistryWithProvider(provider, 30*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	key := WatchKey{GVR: secretsGVR, Namespace: "shared", Identity: "team-a/reader"}
+
+	if _, err := registry.EnsureWatchSet(ctx, "consumer-1", []WatchRequest{{Key: key, Callback: noopCallback()}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := registry.EnsureWatchSet(ctx, "consumer-2", []WatchRequest{{Key: key, Callback: noopCallback()}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	if len(registry.watches) != 1 {
+		t.Errorf("expected 1 shared watch entry, got %d", len(registry.watches))
+	}
+	if len(registry.watches[key].handlers) != 2 {
+		t.Errorf("expected 2 handlers on shared informer, got %d", len(registry.watches[key].handlers))
+	}
+
+	// Client resolved only once — second consumer reuses the running informer
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.calls) != 1 {
+		t.Errorf("expected 1 ClientFor call, got %d (%v)", len(provider.calls), provider.calls)
+	}
+}
+
+func TestEnsureWatchSet_IdentityChangeSwapsWatches(t *testing.T) {
+	provider := newFakeClientProvider()
+	registry := NewWatchRegistryWithProvider(provider, 30*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	oldKey := WatchKey{GVR: secretsGVR, Namespace: "shared", Identity: "team-a/old-sa"}
+	newKey := WatchKey{GVR: secretsGVR, Namespace: "shared", Identity: "team-a/new-sa"}
+
+	if _, err := registry.EnsureWatchSet(ctx, "consumer-1", []WatchRequest{{Key: oldKey, Callback: noopCallback()}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := registry.EnsureWatchSet(ctx, "consumer-1", []WatchRequest{{Key: newKey, Callback: noopCallback()}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	if _, ok := registry.watches[oldKey]; ok {
+		t.Error("expected old-identity watch to be released after identity change")
+	}
+	if _, ok := registry.watches[newKey]; !ok {
+		t.Error("expected new-identity watch to exist")
+	}
+	if len(registry.consumerKeys["consumer-1"]) != 1 {
+		t.Errorf("expected 1 consumer key, got %d", len(registry.consumerKeys["consumer-1"]))
+	}
+}
+
+func TestEnsureWatchSet_ProviderErrorRollsBack(t *testing.T) {
+	provider := newFakeClientProvider()
+	provider.errFor["team-b/broken"] = context.DeadlineExceeded // any error
+	registry := NewWatchRegistryWithProvider(provider, 30*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	goodKey := WatchKey{GVR: secretsGVR, Namespace: "shared", Identity: "team-a/reader"}
+	badKey := WatchKey{GVR: secretsGVR, Namespace: "shared", Identity: "team-b/broken"}
+
+	// Fresh consumer: the good watch is added, then the bad one fails —
+	// the good one must be rolled back so the consumer stays unregistered.
+	_, err := registry.EnsureWatchSet(ctx, "consumer-1", []WatchRequest{
+		{Key: goodKey, Callback: noopCallback()},
+		{Key: badKey, Callback: noopCallback()},
+	})
+	if err == nil {
+		t.Fatal("expected error from failing provider")
+	}
+
+	registry.mu.Lock()
+	if len(registry.watches) != 0 {
+		t.Errorf("expected all watches rolled back, got %d", len(registry.watches))
+	}
+	if len(registry.consumerKeys) != 0 {
+		t.Errorf("expected no consumer keys after rollback, got %d", len(registry.consumerKeys))
+	}
+	registry.mu.Unlock()
+
+	// Consumer with an existing set keeps it when a later ensure fails.
+	if _, err := registry.EnsureWatchSet(ctx, "consumer-1", []WatchRequest{{Key: goodKey, Callback: noopCallback()}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, err = registry.EnsureWatchSet(ctx, "consumer-1", []WatchRequest{
+		{Key: goodKey, Callback: noopCallback()},
+		{Key: badKey, Callback: noopCallback()},
+	})
+	if err == nil {
+		t.Fatal("expected error from failing provider")
+	}
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if _, ok := registry.watches[goodKey]; !ok {
+		t.Error("expected pre-existing watch to survive a failed ensure")
+	}
+	if len(registry.consumerKeys["consumer-1"]) != 1 {
+		t.Errorf("expected consumer to keep its previous 1-key set, got %d", len(registry.consumerKeys["consumer-1"]))
+	}
+}
+
+func TestNewWatchRegistry_RejectsNonEmptyIdentity(t *testing.T) {
+	registry, ctx, cancel := newFakeRegistry(t) // legacy single-client constructor
+	defer cancel()
+
+	_, err := registry.EnsureWatchSet(ctx, "consumer-1", []WatchRequest{
+		{
+			Key:      WatchKey{GVR: deploymentsGVR, Namespace: "default", Identity: "some/identity"},
+			Callback: noopCallback(),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-empty identity on single-client registry")
+	}
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if len(registry.watches) != 0 {
+		t.Errorf("expected no watches, got %d", len(registry.watches))
+	}
+}
+
+func TestWatchKey_IdentityDifferentiatesKeys(t *testing.T) {
+	base := WatchKey{GVR: deploymentsGVR, Namespace: "default"}
+	withID := WatchKey{GVR: deploymentsGVR, Namespace: "default", Identity: "team-a/reader"}
+
+	m := map[WatchKey]int{base: 1}
+	if _, ok := m[withID]; ok {
+		t.Error("expected identity to differentiate otherwise-equal keys")
+	}
+	m[withID] = 2
+	if m[base] != 1 || m[withID] != 2 {
+		t.Error("expected both keys to coexist in the map")
 	}
 }
 


### PR DESCRIPTION
Add an opaque Identity field to WatchKey and a ClientProvider interface so informers for the same GVR+namespace under different identities never share a watch. NewWatchRegistryWithProvider resolves the client per identity when an informer starts; the existing NewWatchRegistry keeps its single-client behavior (empty identity only) so current consumers
are unaffected. The registry treats identities as opaque — what an identity maps to (impersonation, tokens, remote clusters) is entirely the provider implementation's concern.
